### PR TITLE
replacing system.printlns with logs, hides junit testing logs when doing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
 				<configuration>
   					<argLine>-Xmx1024m</argLine>
 					<junitArtifactName>org.junit:com.springsource.org.junit</junitArtifactName>
+					<redirectTestOutputToFile>true</redirectTestOutputToFile>
 				</configuration>	
 			</plugin>
 			<plugin>

--- a/src/test/java/org/geppetto/model/neuroml/test/LEMSConversionServiceTest.java
+++ b/src/test/java/org/geppetto/model/neuroml/test/LEMSConversionServiceTest.java
@@ -42,6 +42,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.geppetto.core.beans.PathConfiguration;
 import org.geppetto.core.conversion.ConversionException;
 import org.geppetto.core.data.model.local.LocalAspectConfiguration;
@@ -72,6 +74,9 @@ import org.neuroml.model.util.NeuroMLException;
  */
 public class LEMSConversionServiceTest
 {
+	
+	private static Log _logger = LogFactory.getLog(LEMSConversionServiceTest.class);
+	
 	// FIXME: We have to use OSGI text or spring app context initialization
 	@BeforeClass
 	public static void initializeServiceRegistry() throws Exception
@@ -171,7 +176,7 @@ public class LEMSConversionServiceTest
 		{
 			for(File child : directoryListing)
 			{
-				System.out.println(child.getName());
+				_logger.info(child.getName());
 				File expectedFile = new File(LEMSConversionServiceTest.class.getClassLoader().getResource(expectedFolder + child.getName()).toURI());
 				Assert.assertEquals(FileUtils.readLines(expectedFile), FileUtils.readLines(child));
 			}

--- a/src/test/java/org/geppetto/model/neuroml/test/NeuroMLModelInterpreterServiceTest.java
+++ b/src/test/java/org/geppetto/model/neuroml/test/NeuroMLModelInterpreterServiceTest.java
@@ -37,18 +37,17 @@ package org.geppetto.model.neuroml.test;
 import java.io.File;
 import java.util.Set;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.AbstractMap.SimpleEntry;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map.Entry;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.geppetto.model.neuroml.modelInterpreterUtils.PopulateProjectionTypes;
 import org.geppetto.model.neuroml.services.NeuroMLModelInterpreterService;
 import org.junit.Before;
-import org.junit.AfterClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -58,7 +57,6 @@ import org.geppetto.model.types.ArrayType;
 import org.geppetto.model.variables.Variable;
 import org.geppetto.model.types.ImportType;
 import org.geppetto.model.values.ArrayElement;
-import org.geppetto.model.variables.Variable;
 
 import org.neuroml.model.util.NeuroMLConverter;
 import org.neuroml.model.NeuroMLDocument;
@@ -68,8 +66,6 @@ import org.neuroml.model.Instance;
 import org.neuroml.model.util.hdf5.NeuroMLHDF5Reader;
 
 import org.lemsml.jlems.core.type.Component;
-import org.lemsml.jlems.core.type.ComponentType;
-import org.lemsml.jlems.core.type.Lems;
 
 /**
  * @author Adrian Quintana (adrian.perez@ucl.ac.uk)
@@ -77,6 +73,8 @@ import org.lemsml.jlems.core.type.Lems;
  */
 public class NeuroMLModelInterpreterServiceTest
 {
+	private static Log _logger = LogFactory.getLog(NeuroMLModelInterpreterServiceTest.class);
+	
     private ModelTester mTest;
 
     @Before
@@ -120,7 +118,7 @@ public class NeuroMLModelInterpreterServiceTest
         	
             // Make some comparisons between read Geppetto model and NeuroML document as read by org.neuroml.model
             assertEquals(nmlDoc.getId(), geppettoModel.getId());
-            System.out.println("Comparing NML model " + nmlDoc.getId() + " to Geppetto: " + geppettoModel.getId());
+            _logger.info("Comparing NML model " + nmlDoc.getId() + " to Geppetto: " + geppettoModel.getId());
 
             // Populations (compare id and size)
             List<Population> docPopulations = nmlDoc.getNetwork().get(0).getPopulation();
@@ -150,10 +148,10 @@ public class NeuroMLModelInterpreterServiceTest
                 modelPosSummary.add(new SimpleEntry<Integer, String>(el.getIndex(), "(" + (float) el.getPosition().getX() + "," + (float) el.getPosition().getY() + "," + (float) el.getPosition().getZ() + ")"));
             }
 
-            System.out.println("modelPopSummary: " + modelPopSummary);
-            System.out.println("modelPosSummary: " + modelPosSummary);
-            System.out.println("docPopSummary: " + docPopSummary);
-            System.out.println("docPosSummary: " + docPosSummary);
+            _logger.info("modelPopSummary: " + modelPopSummary);
+            _logger.info("modelPosSummary: " + modelPosSummary);
+            _logger.info("docPopSummary: " + docPopSummary);
+            _logger.info("docPosSummary: " + docPosSummary);
 
             assertEquals(modelPopSummary, docPopSummary);
             assertEquals(modelPosSummary, docPosSummary);
@@ -167,7 +165,7 @@ public class NeuroMLModelInterpreterServiceTest
             for (Projection proj : docProjections)
             {
                 int total = proj.getConnection().size() + proj.getConnectionWD().size();
-                System.out.println("Model has proj " + proj.getId() + " with " + total + " conns");
+                _logger.info("Model has proj " + proj.getId() + " with " + total + " conns");
                 docProjSummary.put(proj.getId(), total);
             }
 
@@ -188,7 +186,7 @@ public class NeuroMLModelInterpreterServiceTest
 
                     modelProjSummary.put(resolvedProj.getId(), resolvedProjSize);
 
-                    System.out.println(projComponent.getID() + " = " + projComponent.getStrictChildren().size() + " = " + docProjSummary.get(projComponent.getID()));
+                    _logger.info(projComponent.getID() + " = " + projComponent.getStrictChildren().size() + " = " + docProjSummary.get(projComponent.getID()));
                 }
 
                 assertEquals(modelProjSummary, docProjSummary);

--- a/src/test/java/org/geppetto/model/neuroml/test/OptimizedLEMSReaderTest.java
+++ b/src/test/java/org/geppetto/model/neuroml/test/OptimizedLEMSReaderTest.java
@@ -37,6 +37,9 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 import java.util.ArrayList;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.geppetto.model.neuroml.utils.OptimizedLEMSReader;
 import org.junit.Test;
 import org.lemsml.jlems.core.sim.LEMSException;
@@ -50,6 +53,8 @@ import org.neuroml.model.util.NeuroMLException;
  */
 public class OptimizedLEMSReaderTest
 {
+	private static Log _logger = LogFactory.getLog(OptimizedLEMSReaderTest.class);
+	
     private void loadNeuroMLFile(String modelPath) throws IOException, NeuroMLException, LEMSException
     {
 
@@ -57,10 +62,10 @@ public class OptimizedLEMSReaderTest
 
         URL url = ModelInterpreterTestUtils.class.getResource(modelPath);
         OptimizedLEMSReader olr = new OptimizedLEMSReader(dependentModels);
-        System.out.println("Loading: "+modelPath);
+        _logger.info("Loading: "+modelPath);
         olr.readAllFormats(url);
 
-        System.out.println("Done: "+olr.getNetworkHelper());
+        _logger.info("Done: "+olr.getNetworkHelper());
 
     }
 

--- a/src/test/java/org/geppetto/model/neuroml/test/PopulateSummaryNodesUtilsTest.java
+++ b/src/test/java/org/geppetto/model/neuroml/test/PopulateSummaryNodesUtilsTest.java
@@ -39,6 +39,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.eclipse.emf.common.command.BasicCommandStack;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -54,7 +57,6 @@ import org.geppetto.model.GeppettoFactory;
 import org.geppetto.model.GeppettoLibrary;
 import org.geppetto.model.GeppettoModel;
 import org.geppetto.model.GeppettoPackage;
-
 import org.geppetto.model.neuroml.services.NeuroMLModelInterpreterService;
 import org.geppetto.model.neuroml.summaryUtils.PopulateSummaryNodesUtils;
 import org.geppetto.model.types.Type;
@@ -69,6 +71,7 @@ import org.neuroml.model.NeuroMLDocument;
  */
 public class PopulateSummaryNodesUtilsTest
 {
+	private static Log _logger = LogFactory.getLog(PopulateSummaryNodesUtilsTest.class);
 	
     /*
        This is really just a helper class to allow update/testing of generated HTML in
@@ -129,7 +132,7 @@ public class PopulateSummaryNodesUtilsTest
     public void testModelACnet() throws Exception
     {
         modelInterpreterTestUtils.serialise("/acnet2/MediumNet.net.nml", null, new NeuroMLModelInterpreterService());
-        System.out.println("============================================");
+        _logger.info("============================================");
         modelInterpreterTestUtils.serialise("/acnet2/pyr_4_sym.cell.nml", null, new NeuroMLModelInterpreterService());
     }
 


### PR DESCRIPTION
This branch replaces some system.println statements found in the junit tests with log4j logging, this was done to be able to silence logging with the --quiet parameter when  doing mvn install. 